### PR TITLE
Bind pubsub to callback function. Fixes #2

### DIFF
--- a/html/example_multiple/example_multiple_main.js
+++ b/html/example_multiple/example_multiple_main.js
@@ -60,10 +60,10 @@ define([
           initDocumentWidgets(wrappers[i], factories, pubsub);
 
           pubsub.subscribe('allFontsLoaded', function () {
-              pubsub.publish('activateFont', 0);
-          });
+              this.publish('activateFont', 0);
+          }.bind(pubsub));
 
-          loadFonts.fromUrl(pubsub, fontFilesForInstance); 
+          loadFonts.fromUrl(pubsub, fontFilesForInstance);
         }
     }
 


### PR DESCRIPTION
This was a bit subtle: In the for loop, the name `pubsub` is getting assigned a `new PubSub` instance on each iteration. The callback function for `allFontsLoaded`, as a closure, looks up the name in its enclosing namespace. There `pubsub` has the state of the last iteration.